### PR TITLE
Add ability to update rate limiter

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/GuaranteedThroughputSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/GuaranteedThroughputSampler.java
@@ -62,7 +62,7 @@ public final class GuaranteedThroughputSampler implements Sampler {
       isUpdated = true;
     }
     if (lowerBound != lowerBoundSampler.getMaxTracesPerSecond()) {
-      lowerBoundSampler = new RateLimitingSampler(lowerBound);
+      lowerBoundSampler.update(lowerBound);
       isUpdated = true;
     }
     return isUpdated;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -25,6 +25,7 @@ import lombok.ToString;
 @ToString(exclude = "rateLimiter")
 public class RateLimitingSampler implements Sampler {
   public static final String TYPE = "ratelimiting";
+  private static final double MINUMUM_BALANCE = 1.0;
 
   private final RateLimiter rateLimiter;
   @Getter
@@ -42,7 +43,7 @@ public class RateLimitingSampler implements Sampler {
 
   @Override
   public synchronized SamplingStatus sample(String operation, long id) {
-    return SamplingStatus.of(this.rateLimiter.checkCredit(1.0), tags);
+    return SamplingStatus.of(this.rateLimiter.checkCredit(MINUMUM_BALANCE), tags);
   }
 
   @Override
@@ -67,7 +68,7 @@ public class RateLimitingSampler implements Sampler {
   }
 
   private double getMaxBalance(double maxTracesPerSecond) {
-    return maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
+    return maxTracesPerSecond < MINUMUM_BALANCE ? MINUMUM_BALANCE : maxTracesPerSecond;
   }
 
   /**

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -16,7 +16,6 @@ package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.utils.RateLimiter;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -29,27 +28,25 @@ public class RateLimitingSampler implements Sampler {
 
   private final RateLimiter rateLimiter;
   @Getter
-  private final double maxTracesPerSecond;
+  private double maxTracesPerSecond;
   private final Map<String, Object> tags;
 
   public RateLimitingSampler(double maxTracesPerSecond) {
     this.maxTracesPerSecond = maxTracesPerSecond;
-    double maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
-    this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);
+    this.rateLimiter = new RateLimiter(maxTracesPerSecond, getMaxBalance(maxTracesPerSecond));
 
-    Map<String, Object> tags = new HashMap<String, Object>();
+    this.tags = new HashMap<String, Object>();
     tags.put(Constants.SAMPLER_TYPE_TAG_KEY, TYPE);
     tags.put(Constants.SAMPLER_PARAM_TAG_KEY, maxTracesPerSecond);
-    this.tags = Collections.unmodifiableMap(tags);
   }
 
   @Override
-  public SamplingStatus sample(String operation, long id) {
+  public synchronized SamplingStatus sample(String operation, long id) {
     return SamplingStatus.of(this.rateLimiter.checkCredit(1.0), tags);
   }
 
   @Override
-  public boolean equals(Object other) {
+  public synchronized boolean equals(Object other) {
     if (this == other) {
       return true;
     }
@@ -57,6 +54,20 @@ public class RateLimitingSampler implements Sampler {
       return this.maxTracesPerSecond == ((RateLimitingSampler) other).maxTracesPerSecond;
     }
     return false;
+  }
+
+  public synchronized boolean update(double maxTracesPerSecond) {
+    if (this.maxTracesPerSecond == maxTracesPerSecond) {
+      return false;
+    }
+    this.maxTracesPerSecond = maxTracesPerSecond;
+    rateLimiter.update(maxTracesPerSecond, getMaxBalance(maxTracesPerSecond));
+    tags.put(Constants.SAMPLER_PARAM_TAG_KEY, maxTracesPerSecond);
+    return true;
+  }
+
+  private double getMaxBalance(double maxTracesPerSecond) {
+    return maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
   }
 
   /**

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
@@ -19,6 +19,7 @@ import java.util.Random;
 public class RateLimiter {
 
   private static final double SECONDS_IN_NANOSECONDS = 1.0e9;
+  private static final Random RANDOM = new Random();
 
   private double creditsPerNanosecond;
   private final Clock clock;
@@ -27,7 +28,7 @@ public class RateLimiter {
   private long lastTick;
 
   public RateLimiter(double creditsPerSecond, double maxBalance) {
-    this(creditsPerSecond, maxBalance, new SystemClock(), maxBalance * new Random().nextDouble());
+    this(creditsPerSecond, maxBalance, new SystemClock(), maxBalance * RANDOM.nextDouble());
   }
 
   public RateLimiter(double creditsPerSecond, double maxBalance, Clock clock, double initialBalance) {

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/ConstSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/ConstSamplerTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Map;
 import org.junit.Test;
 
-public class TestConstSampler {
+public class ConstSamplerTest {
   @Test
   public void testTags() {
     ConstSampler sampler = new ConstSampler(true);

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/RateLimitingSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/RateLimitingSamplerTest.java
@@ -15,16 +15,24 @@
 package com.uber.jaeger.samplers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 import org.junit.Test;
 
-public class TestRateLimitingSampler {
+public class RateLimitingSamplerTest {
   @Test
   public void testTags() {
     RateLimitingSampler sampler = new RateLimitingSampler(123);
     Map<String, Object> tags = sampler.sample("operate", 11).getTags();
     assertEquals("ratelimiting", tags.get("sampler.type"));
     assertEquals(123.0, tags.get("sampler.param"));
+
+    assertFalse(sampler.update(123));
+
+    assertTrue(sampler.update(42));
+    tags = sampler.sample("operate", 11).getTags();
+    assertEquals(42.0, tags.get("sampler.param"));
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
@@ -46,7 +46,7 @@ public class RateLimiterTest {
   @Test
   public void testRateLimiterWholeNumber() {
     MockClock clock = new MockClock();
-    RateLimiter limiter = new RateLimiter(2.0, 2.0, clock);
+    RateLimiter limiter = new RateLimiter(2.0, 2.0, clock, 2.0);
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
@@ -79,7 +79,7 @@ public class RateLimiterTest {
   @Test
   public void testRateLimiterLessThanOne() {
     MockClock clock = new MockClock();
-    RateLimiter limiter = new RateLimiter(0.5, 0.5, clock);
+    RateLimiter limiter = new RateLimiter(0.5, 0.5, clock, 0.5);
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
@@ -112,7 +112,7 @@ public class RateLimiterTest {
   @Test
   public void testRateLimiterMaxBalance() {
     MockClock clock = new MockClock();
-    RateLimiter limiter = new RateLimiter(0.1, 1.0, clock);
+    RateLimiter limiter = new RateLimiter(0.1, 1.0, clock, 1.0);
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
@@ -126,4 +126,23 @@ public class RateLimiterTest {
     assertTrue(limiter.checkCredit(1.0));
     assertFalse(limiter.checkCredit(1.0));
   }
+
+  @Test
+  public void testRateLimiterUpdate() {
+    RateLimiter limiter = new RateLimiter(3.0, 3.0, new MockClock(), 3.0);
+  
+    // After this call, there should be 2 credits left.
+    assertTrue(limiter.checkCredit(1.0));
+  
+    // Update to a max balance of 1 should only leave 2/3 credits, not enough for a message.
+    limiter.update(1.0, 1.0);
+    assertFalse(limiter.checkCredit(1.0));
+  
+    // Revert back to max balance of 3, there should be 2 credits available.
+    limiter.update(3.0, 3.0);
+    assertTrue(limiter.checkCredit(1.0));
+    assertTrue(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+  }
 }
+


### PR DESCRIPTION
Signed-off-by: Won Jun Jang <wjang@uber.com>

## Which problem is this PR solving?
- The current way the rate limiting sampler is updated involves the sampler being reconstructed; this has the unfortunate side effect of the balance being reinitialized to full which will generate a new sample. If you are updating thousands of instances with a new rate limiting rate, this will generate thousands of new traces. This PR adds the ability to update the rate limiter so that the proportional balance is retained on update.

cf. jaegertracing/jaeger-client-go#320